### PR TITLE
Improve (and speedup) serial_queue

### DIFF
--- a/prusa_link/command.py
+++ b/prusa_link/command.py
@@ -91,14 +91,14 @@ class Command:
         wait_for_instruction(instruction, lambda: self.running)
 
     def do_instruction(self, gcode):
-        instruction = enqueue_instruction(self.serial_queue, gcode, front=True)
+        instruction = enqueue_instruction(self.serial_queue, gcode, to_front=True)
         self.wait_for_instruction(instruction)
         return instruction
 
     def do_matchable(self, gcode, regexp: re.Pattern):
         """Enqueues everything to front as commands have a higher priority"""
         instruction = enqueue_matchable(self.serial_queue, gcode, regexp,
-                                        front=True)
+                                        to_front=True)
         self.wait_for_instruction(instruction)
         return instruction
 

--- a/prusa_link/input_output/serial/helpers.py
+++ b/prusa_link/input_output/serial/helpers.py
@@ -1,10 +1,10 @@
 import re
 from typing import List, Callable
 
+from prusa_link.default_settings import get_settings
 from prusa_link.input_output.serial.instruction import Instruction, \
     MatchableInstruction, CollectingInstruction
 from prusa_link.input_output.serial.serial_queue import SerialQueue
-from prusa_link.default_settings import get_settings
 
 TIME = get_settings().TIME
 
@@ -17,19 +17,19 @@ def wait_for_instruction(instruction, should_wait: Callable[[], bool],
             break
 
 
-def enqueue_instruction(queue: SerialQueue, message: str, front=False,
+def enqueue_instruction(queue: SerialQueue, message: str, to_front=False,
                         to_checksum=False) -> Instruction:
     instruction = Instruction(message, to_checksum=to_checksum)
-    queue.enqueue_one(instruction, front=front)
+    queue.enqueue_one(instruction, to_front=to_front)
     return instruction
 
 
 def enqueue_matchable(queue: SerialQueue,
-                      message: str, regexp: re.Pattern, front=False,
+                      message: str, regexp: re.Pattern, to_front=False,
                       to_checksum=False) -> MatchableInstruction:
     instruction = MatchableInstruction(message, capture_matching=regexp,
                                        to_checksum=to_checksum)
-    queue.enqueue_one(instruction, front=front)
+    queue.enqueue_one(instruction, to_front=to_front)
     return instruction
 
 

--- a/prusa_link/input_output/serial/instruction.py
+++ b/prusa_link/input_output/serial/instruction.py
@@ -1,11 +1,6 @@
-import logging
 import re
 from enum import Enum
 from threading import Event
-
-from blinker import Signal
-
-from prusa_link.structures.regular_expressions import CONFIRMATION_REGEX
 
 
 class Instruction:
@@ -30,15 +25,8 @@ class Instruction:
         # Event set when the write has been _confirmed by the printer
         self.confirmed_event = Event()
 
-        # The plan is to move from waiting for events to reacting to them
-        # using blinker signals
-        self.confirmed_signal = Signal()
-
         # Event set when the write has been sent to the printer
         self.sent_event = Event()
-
-        # Signal sent on the same ocasion
-        self.sent_signal = Signal()
 
         # Api for registering instruction regexps
         self.capturing_regexps = []
@@ -56,12 +44,10 @@ class Instruction:
             return False
 
         self.confirmed_event.set()
-        self.confirmed_signal.send(self)
         return True
 
     def sent(self):
         self.sent_event.set()
-        self.sent_signal.send(self)
 
     def output_captured(self, sender, match):
         pass

--- a/prusa_link/input_output/serial/serial_reader.py
+++ b/prusa_link/input_output/serial/serial_reader.py
@@ -3,9 +3,9 @@ import re
 from re import Match
 from threading import Lock
 from typing import Dict, List, Callable
-from sortedcontainers import SortedList, SortedKeyList
 
 from blinker import Signal
+from sortedcontainers import SortedKeyList
 
 from prusa_link.default_settings import get_settings
 


### PR DESCRIPTION
Instead of inserting instructions into a list O(n) put them into two queues, one for important instructions handled first, other for telemetry and such. Use current_instruction for the currently handled instruction instead of looking at the top of the queue all the time.