### PR TITLE
Use names required by Connect.

### DIFF
--- a/prusa/link/printer_adapter/command_handlers/job_info.py
+++ b/prusa/link/printer_adapter/command_handlers/job_info.py
@@ -20,11 +20,11 @@ class JobInfo(ResponseCommand):
             self.failed("Cannot get job info, "
                         "when there is no job in progress.")
 
-        values = self.state_manager.job.get_job_info_data()
+        data = self.state_manager.job.get_job_info_data()
 
         self.printer.event_cb(event=Event.JOB_INFO,
                               source=Source.CONNECT,
                               command_id=self.caller.command_id,
                               job_id=self.state_manager.job.get_job_id(),
                               state=self.state_manager.get_state().value,
-                              values=values)
+                              **data)

--- a/prusa/link/printer_adapter/informers/job.py
+++ b/prusa/link/printer_adapter/informers/job.py
@@ -147,9 +147,9 @@ class Job:
             data["filename_only"] = self.filename_only
 
         if self.job_start_cmd_id is not None:
-            data["job_start_cmd_id"] = self.job_start_cmd_id
+            data["start_cmd_id"] = self.job_start_cmd_id
 
         if self.printing_file_path is not None:
-            data["printing_file_path"] = self.printing_file_path
+            data["file_path"] = self.printing_file_path
 
         return data


### PR DESCRIPTION
FYI: printing = action, printed = adjective, thus I think it should be printed_file or just print_file