### PR TITLE
Get rid of the serial queue on printer reset, fixes multi-resets

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -11,6 +11,7 @@
     * Fix printer.sn being unset in the wizard by waiting for it
     * Fixed some telemetry being sent basically at random
     * Enabled the RESET_PRINTER command
+    * Fixed printer resetting multiple times when it gets reset mid-print
 
 0.2.0 (2020-12-14)
 

--- a/prusa/link/printer_adapter/file_printer.py
+++ b/prusa/link/printer_adapter/file_printer.py
@@ -19,7 +19,7 @@ from prusa.link.printer_adapter.input_output.serial.helpers import \
 from prusa.link.printer_adapter.print_stats import PrintStats
 from prusa.link.printer_adapter.structures.mc_singleton import MCSingleton
 from prusa.link.printer_adapter.structures.regular_expressions import \
-    POWER_PANIC_REGEX, PRINTER_BOOT_REGEX, ERROR_REGEX, RESUMED_REGEX
+    POWER_PANIC_REGEX, ERROR_REGEX, RESUMED_REGEX
 from prusa.link.printer_adapter.util import get_clean_path, ensure_directory, \
     get_gcode
 
@@ -51,8 +51,6 @@ class FilePrinter(metaclass=MCSingleton):
         self.serial_queue.serial_queue_failed.connect(
             lambda sender: self.stop_print())
 
-        self.serial_reader.add_handler(
-            PRINTER_BOOT_REGEX, lambda sender, match: self.printer_reset())
         self.serial_reader.add_handler(
             POWER_PANIC_REGEX, lambda sender, match: self.power_panic())
         self.serial_reader.add_handler(
@@ -212,9 +210,6 @@ class FilePrinter(metaclass=MCSingleton):
         print_ending = (gcode_number ==
                         self.print_stats.total_gcode_count - FP.TAIL_COMMANDS)
         return (do_stats and divisible) or print_ending
-
-    def printer_reset(self):
-        self.stop_print()
 
     def printer_error(self):
         # TODO: Maybe pause in some cases instead

--- a/prusa/link/printer_adapter/info_sender.py
+++ b/prusa/link/printer_adapter/info_sender.py
@@ -12,8 +12,6 @@ from prusa.link.printer_adapter.input_output.serial.serial_queue import \
 from prusa.link.printer_adapter.input_output.serial.serial_reader import \
     SerialReader
 from prusa.link.printer_adapter.model import Model
-from prusa.link.printer_adapter.structures.regular_expressions import \
-    PRINTER_BOOT_REGEX
 
 LOG = get_settings().LOG
 TIME = get_settings().TIME
@@ -35,10 +33,6 @@ class InfoSender:
 
         self.info_updating_thread = None
         self.running = True
-
-        # Try sending info after every reset
-        self.serial_reader.add_handler(
-            PRINTER_BOOT_REGEX, lambda sender, match: self.try_sending_info())
 
     def update_info(self):
         self.printer.network_info = get_network_info(


### PR DESCRIPTION
Also, if the printer was printing, it sends M603 so the nozzle doesn't stay in the print