### PR TITLE
Add a filename_too_long attribute to sd tree nodes

### DIFF
--- a/prusa/link/printer_adapter/const.py
+++ b/prusa/link/printer_adapter/const.py
@@ -49,6 +49,7 @@ TAIL_COMMANDS = 10  # how many commands after the last progress report
 PRINT_QUEUE_SIZE = 4
 
 # --- Mountpoints ---
+MAX_FILENAME_LENGTH = 52
 SD_MOUNT_NAME = "SD Card"
 BLACKLISTED_TYPES = [
 ]


### PR DESCRIPTION
Also, use the format "SFN - LFN" for every file whose filename exceeds the 52 char limit