### PR TITLE
Require user attention after each print, even failed ones (if enabled)

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -24,6 +24,7 @@
     * Password in plain text form is not stored in memory
     * Added endpoint for gettting info about the file currently being downloaded
     * Added endpoint for abort current download process
+    * Require user attention after each print, even failed ones (if enabled)
 
 0.4.0 (2021-04-13)
     * getting IP refactoring

--- a/prusa/link/config.py
+++ b/prusa/link/config.py
@@ -105,8 +105,8 @@ class Config(Get):
         if args.pidfile:
             self.daemon.pid_file = abspath(args.pidfile)
 
-        for file_ in ('pid_file', 'power_panic_file',
-                      'job_file', 'threshold_file'):
+        for file_ in ('pid_file', 'power_panic_file', 'job_file',
+                      'threshold_file'):
             setattr(
                 self.daemon, file_,
                 abspath(join(self.daemon.data_dir, getattr(self.daemon,
@@ -156,6 +156,7 @@ class Config(Get):
                     ("mountpoints", tuple, [], ':'),
                     # relative to HOME
                     ("directories", tuple, ("./Prusa Link gcodes", ), ':'),
+                    ("M0_after_prints", bool, True),
                 )))
         if args.serial_port:
             self.printer.port = args.serial_port

--- a/prusa/link/printer_adapter/command_handlers.py
+++ b/prusa/link/printer_adapter/command_handlers.py
@@ -109,7 +109,7 @@ class StopPrint(TryUntilState):
             self.file_printer.stop_print()
 
         # There might be an edge case with FINISHED, so let's wait for READY
-        self._try_until_state(gcode="M603", desired_state=State.READY)
+        self._try_until_state(gcode="M603", desired_state=State.STOPPED)
 
 
 class PausePrint(TryUntilState):


### PR DESCRIPTION
I think that users, like myself don't like their hands held to such an extent, so I made an option for disabling this.
When disabled, checked is sent as False, so it can be still detected.