### PR TITLE
move M0_after_prints to prusa_printer_settings.ini

### DIFF
--- a/prusa/link/config.py
+++ b/prusa/link/config.py
@@ -224,7 +224,7 @@ class Settings(Get):
         self.printer = Model(
             self.get_section('printer',
                              (('type', str, 'MK3'), ('name', str, ''),
-                              ('location', str, ''), ('M0_after_prints', int, 0))))
+                              ('location', str, ''), ('prompt_clean_sheet', int, 0))))
 
         if self.printer.type != 'MK3':
             raise ValueError("Settings file for different printer!")

--- a/prusa/link/printer_adapter/informers/state_manager.py
+++ b/prusa/link/printer_adapter/informers/state_manager.py
@@ -93,7 +93,7 @@ class StateManager(metaclass=MCSingleton):
     to other PrusaLink components
     """
 
-    # pylint: disable=too-many-instance-attributes,too-many-public-methods
+    # pylint: disable=too-many-instance-attributes,too-many-public-methods,too-many-arguments
     def __init__(self, serial_reader: SerialReader, model: Model,
                  sdk_printer: Printer, cfg: Config, settings: Settings):
 
@@ -529,7 +529,7 @@ class StateManager(metaclass=MCSingleton):
         if self.data.base_state == State.BUSY:
             self.data.base_state = State.READY
 
-        if not self.settings.printer.M0_after_prints:
+        if not self.settings.printer.prompt_clean_sheet:
             if self.data.printing_state in {State.STOPPED, State.FINISHED}:
                 self.data.printing_state = None
 

--- a/prusa/link/printer_adapter/prusa_link.py
+++ b/prusa/link/printer_adapter/prusa_link.py
@@ -609,7 +609,7 @@ class PrusaLink:
             InterestingLogRotator.trigger(
                 "by the printer entering the ERROR state.")
             self.file_printer.stop_print()
-        if self.settings.printer.M0_after_prints:
+        if self.settings.printer.prompt_clean_sheet:
             if to_state == State.FINISHED:
                 Thread(target=self.check_printer,
                        args=("Done, remove print",


### PR DESCRIPTION
This is likely a breaking change. 

example implementation strategy:
- new Prusa-Link code version is shipped to RPI
- prusa-link process needs to be restarted.
- endpoint /api/settings needs to be hit with POST request
otherwise .ini file won't be updated with new m0_after_prints variable

Other option is some sort of a one off script executing this code (from api_settings_set endpoint):
   

    settings = app.daemon.settings
    cfg = app.daemon.cfg

    name = settings.printer.name = req.json.get('name')
    location = settings.printer.location = req.json.get('location')

    settings.update_sections()

    with open(cfg.printer.settings, 'w') as ini:
        settings.write(ini)

