### PR TITLE
Require two "Not SD printing" to work around a SD printing bug

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -34,6 +34,7 @@
     * Added m_timestamp to SDCard files properties
     * Added api/settings POST endpoint, fix settings.py name
     * Fixed /api/printer flags
+    * Require two "Not SD printing" to work around a SD printing bug
 
 0.4.0 (2021-04-13)
     * getting IP refactoring

--- a/prusa/link/printer_adapter/prusa_link.py
+++ b/prusa/link/printer_adapter/prusa_link.py
@@ -110,7 +110,8 @@ class PrusaLink:
                                       self.model)
         self.job = Job(self.serial_reader, self.model, self.cfg, self.printer)
         self.state_manager = StateManager(self.serial_reader, self.model,
-                                          self.printer, self.cfg, self.settings)
+                                          self.printer, self.cfg,
+                                          self.settings)
         self.telemetry_gatherer = TelemetryGatherer(self.serial_reader,
                                                     self.serial_queue,
                                                     self.model)
@@ -603,6 +604,7 @@ class PrusaLink:
         assert to_state is not None
         if source is None:
             source = Source.WUI
+            InterestingLogRotator.trigger("by an unexpected state change.")
             log.warning("State change had no source %s", to_state.value)
 
         if to_state == State.ERROR:


### PR DESCRIPTION
When starting an SD print from the LCD this would happen 

```
Printer says: 'ok' 
Printer says: 'echo:Now fresh file: hesapi~1.gco' 
Printer says: 'File opened: /HesAPirate.gcode Size: 7023'
Printer says: 'File selected' 
Printer says: 'LCD status changed' 
Printer says: 'LCD status changed' 
Printer says: 'T:25.3 /0.0 B:25.4 /0.0 T0:25.3 /0.0 @:0 B@:0 P:26.3 A:27.0' 
Printer says: 'X:0.00 Y:0.00 Z:0.15 E:0.00 Count X: 0.00 Y:0.00 Z:0.15 E:0.00' 
Printer says: 'E0:0 RPM PRN1:0 RPM E0@:0 PRN1@:0' 
Printer says: 'echo:enqueing "M23 hesapi~1.gco"' 
Printer says: 'echo:enqueing "M24"'      <--- Triggers PRINTING
Printer says: 'Not SD printing'      <--- Triggers STOPPED and sends M0 to confirm clean buildplate
Printer says: 'ok' 
Printer says: 'echo:Now fresh file: hesapi~1.gco'      <--- Continues to print untill M0 is processed "pausing" the print
Printer says: 'File opened: /HesAPirate.gcode Size: 7023' 
Printer says: 'File selected' 
Printer says: 'LCD status changed' 
Printer says: '0.40' 
Printer says: 'ok'
```