### PR TITLE
Do not merge! I just need to tell you something about this branch. It's sticky STOPPED and FINISHED states

### DIFF
--- a/prusa/link/printer_adapter/command_handlers.py
+++ b/prusa/link/printer_adapter/command_handlers.py
@@ -17,7 +17,7 @@ from prusa.connect.printer.const import State, Source, Event as EventConst
 from .command import Command
 from .informers.state_manager import StateChange
 from .const import STATE_CHANGE_TIMEOUT, QUIT_INTERVAL, RESET_PIN, \
-    PRINTER_BOOT_WAIT, SERIAL_QUEUE_TIMEOUT
+    PRINTER_BOOT_WAIT, SERIAL_QUEUE_TIMEOUT, PRINTING_STATES
 from .input_output.serial.helpers import enqueue_list_from_str
 from .structures.model_classes import JobState
 from .structures.regular_expressions import REJECTION_REGEX, \
@@ -169,7 +169,7 @@ class StartPrint(Command):
 
         # No new print jobs while already printing
         # or when there is an Error/Attention state
-        if self.model.state_manager.printing_state is not None:
+        if self.model.state_manager.printing_state in PRINTING_STATES:
             self.failed("Already printing")
             return
 

--- a/prusa/link/printer_adapter/const.py
+++ b/prusa/link/printer_adapter/const.py
@@ -7,7 +7,7 @@ from typing import List
 from prusa.connect.printer.const import State
 
 BASE_STATES = {State.READY, State.BUSY}
-PRINTING_STATES = {State.PRINTING, State.PAUSED, State.FINISHED, State.STOPPED}
+PRINTING_STATES = {State.PRINTING, State.PAUSED}
 
 JOB_ONGOING_STATES = {State.PRINTING, State.PAUSED}
 JOB_ENDING_STATES = BASE_STATES.union(


### PR DESCRIPTION
It's shit, The FINISHED -> BUSY -> READY means that if the printer gets into a busy state as it stops printing, (which it does) the FINISHED state does not stick half the time, it would take another hack to ignore some of the reported busy things to achieve this.

It seems like we need two things, one observing the printer state as best as it can, and one that will make sense of the observations and report something cleaner, the state_manager tried to achieve both, but it failed, as I did not think about the state reported and printer state as two different things when writing it.

But hey, for testing it still should maybe work, the STOPPED and FINISHED states actually stick when printing from the SD initiated from the LCD