### PR TITLE
Fix the custom serial implementation, so empty reads don't cause errors

### DIFF
--- a/prusa/link/printer_adapter/command.py
+++ b/prusa/link/printer_adapter/command.py
@@ -9,11 +9,11 @@ from prusa.connect.printer.const import Source
 from .file_printer import FilePrinter
 from .informers.job import Job
 from .informers.state_manager import StateManager
-from .input_output.serial.serial import Serial
+from .input_output.serial.serial_adapter import SerialAdapter
 from .input_output.serial.serial_queue import \
     MonitoredSerialQueue
-from .input_output.serial.serial_reader import \
-    SerialReader
+from .input_output.serial.serial_parser import \
+    SerialParser
 from .input_output.serial.helpers import \
     wait_for_instruction, enqueue_matchable, enqueue_instruction
 from .model import Model
@@ -39,8 +39,8 @@ class Command:
     def __init__(self, command_id=None, source=Source.CONNECT):
         self.serial_queue: MonitoredSerialQueue = \
             MonitoredSerialQueue.get_instance()
-        self.serial: Serial = Serial.get_instance()
-        self.serial_reader: SerialReader = SerialReader.get_instance()
+        self.serial_adapter: SerialAdapter = SerialAdapter.get_instance()
+        self.serial_parser: SerialParser = SerialParser.get_instance()
         self.model: Model = Model.get_instance()
         self.printer: MyPrinter = MyPrinter.get_instance()
         self.state_manager: StateManager = StateManager.get_instance()

--- a/prusa/link/printer_adapter/command_handlers.py
+++ b/prusa/link/printer_adapter/command_handlers.py
@@ -392,7 +392,7 @@ class ResetPrinter(Command):
             assert match is not None
             event.set()
 
-        self.serial_reader.add_handler(PRINTER_BOOT_REGEX, waiter)
+        self.serial_parser.add_handler(PRINTER_BOOT_REGEX, waiter)
 
         self.state_manager.expect_change(
             StateChange(default_source=self.source,
@@ -411,13 +411,13 @@ class ResetPrinter(Command):
             wiringpi.digitalWrite(RESET_PIN, wiringpi.LOW)
         else:
             # Maybe use an import error, or something from within wiringpi
-            self.serial.blip_dtr()
+            self.serial_adapter.blip_dtr()
 
         while self.running and time() < times_out_at:
             if event.wait(QUIT_INTERVAL):
                 break
 
-        self.serial_reader.remove_handler(PRINTER_BOOT_REGEX, waiter)
+        self.serial_parser.remove_handler(PRINTER_BOOT_REGEX, waiter)
 
         if time() > times_out_at:
             self.failed("Your printer has ignored the reset signal, your RPi "

--- a/prusa/link/printer_adapter/file_printer.py
+++ b/prusa/link/printer_adapter/file_printer.py
@@ -12,8 +12,8 @@ from .input_output.serial.instruction import \
     Instruction
 from .input_output.serial.serial_queue import \
     SerialQueue
-from .input_output.serial.serial_reader import \
-    SerialReader
+from .input_output.serial.serial_parser import \
+    SerialParser
 from .input_output.serial.helpers import \
     enqueue_instruction, wait_for_instruction
 from .model import Model
@@ -38,10 +38,10 @@ class FilePrinter(metaclass=MCSingleton):
     """
 
     # pylint: disable=too-many-arguments
-    def __init__(self, serial_queue: SerialQueue, serial_reader: SerialReader,
+    def __init__(self, serial_queue: SerialQueue, serial_parser: SerialParser,
                  model: Model, cfg: Config, print_stats: PrintStats):
         self.serial_queue = serial_queue
-        self.serial_reader = serial_reader
+        self.serial_parser = serial_parser
         self.print_stats = print_stats
         self.model = model
 
@@ -66,15 +66,15 @@ class FilePrinter(metaclass=MCSingleton):
         self.serial_queue.serial_queue_failed.connect(
             lambda sender: self.stop_print(), weak=False)
 
-        self.serial_reader.add_handler(
+        self.serial_parser.add_handler(
             POWER_PANIC_REGEX, lambda sender, match: self.power_panic())
-        self.serial_reader.add_handler(
+        self.serial_parser.add_handler(
             ERROR_REGEX, lambda sender, match: self.printer_error())
-        self.serial_reader.add_handler(CANCEL_REGEX,
+        self.serial_parser.add_handler(CANCEL_REGEX,
                                        lambda sender, match: self.stop_print())
-        self.serial_reader.add_handler(PAUSED_REGEX,
+        self.serial_parser.add_handler(PAUSED_REGEX,
                                        lambda sender, match: self.pause())
-        self.serial_reader.add_handler(RESUMED_REGEX,
+        self.serial_parser.add_handler(RESUMED_REGEX,
                                        lambda sender, match: self.resume())
 
         self.thread = None

--- a/prusa/link/printer_adapter/informers/filesystem/sd_card.py
+++ b/prusa/link/printer_adapter/informers/filesystem/sd_card.py
@@ -12,7 +12,7 @@ from prusa.connect.printer.const import State
 
 from ..state_manager import StateManager
 from ...input_output.serial.serial_queue import SerialQueue
-from ...input_output.serial.serial_reader import SerialReader
+from ...input_output.serial.serial_parser import SerialParser
 from ...input_output.serial.helpers import \
     wait_for_instruction, enqueue_matchable, enqueue_collecting
 from ...model import Model
@@ -68,7 +68,7 @@ class SDCard(ThreadedUpdatable):
     # Cycle fast, but re-scan only on events or in big intervals
     update_interval = SD_INTERVAL
 
-    def __init__(self, serial_queue: SerialQueue, serial_reader: SerialReader,
+    def __init__(self, serial_queue: SerialQueue, serial_parser: SerialParser,
                  state_manager: StateManager, model: Model):
 
         self.tree_updated_signal = Signal()  # kwargs: tree: FileTree
@@ -76,9 +76,9 @@ class SDCard(ThreadedUpdatable):
         self.sd_mounted_signal = Signal()  # kwargs: files: SDFile
         self.sd_unmounted_signal = Signal()
 
-        self.serial_reader = serial_reader
-        self.serial_reader.add_handler(SD_PRESENT_REGEX, self.sd_inserted)
-        self.serial_reader.add_handler(SD_EJECTED_REGEX, self.sd_ejected)
+        self.serial_parser = serial_parser
+        self.serial_parser.add_handler(SD_PRESENT_REGEX, self.sd_inserted)
+        self.serial_parser.add_handler(SD_EJECTED_REGEX, self.sd_ejected)
         self.serial_queue: SerialQueue = serial_queue
         self.state_manager = state_manager
         self.model = model

--- a/prusa/link/printer_adapter/informers/filesystem/storage_controller.py
+++ b/prusa/link/printer_adapter/informers/filesystem/storage_controller.py
@@ -14,7 +14,7 @@ from .mounts import FSMounts, DirMounts
 from .sd_card import SDCard
 from ..state_manager import StateManager
 from ...input_output.serial.serial_queue import SerialQueue
-from ...input_output.serial.serial_reader import SerialReader
+from ...input_output.serial.serial_parser import SerialParser
 from ...model import Model
 from ....sdk_augmentation.file import SDFile
 
@@ -29,19 +29,19 @@ class StorageController:
 
     # pylint: disable=too-many-arguments
     def __init__(self, cfg, serial_queue: SerialQueue,
-                 serial_reader: SerialReader, state_manager: StateManager,
+                 serial_parser: SerialParser, state_manager: StateManager,
                  model: Model):
         self.dir_mounted_signal = Signal()
         self.dir_unmounted_signal = Signal()
         self.sd_mounted_signal = Signal()
         self.sd_unmounted_signal = Signal()
 
-        self.serial_reader = serial_reader
+        self.serial_parser = serial_parser
         self.serial_queue: SerialQueue = serial_queue
         self.state_manager = state_manager
         self.model = model
 
-        self.sd_card = SDCard(self.serial_queue, self.serial_reader,
+        self.sd_card = SDCard(self.serial_queue, self.serial_parser,
                               self.state_manager, self.model)
         self.sd_card.sd_mounted_signal.connect(self.sd_mounted)
         self.sd_card.sd_unmounted_signal.connect(self.sd_unmounted)

--- a/prusa/link/printer_adapter/informers/job.py
+++ b/prusa/link/printer_adapter/informers/job.py
@@ -10,7 +10,7 @@ from prusa.connect.printer import Printer
 
 from ..structures.module_data_classes import JobData
 from ...config import Config
-from ..input_output.serial.serial_reader import SerialReader
+from ..input_output.serial.serial_parser import SerialParser
 from ..model import Model
 from ..const import PRINTING_STATES, \
     JOB_ENDING_STATES, BASE_STATES, JOB_ONGOING_STATES, SD_MOUNT_NAME
@@ -24,12 +24,12 @@ log = logging.getLogger(__name__)
 
 class Job(metaclass=MCSingleton):
     """Keeps track of print jobs and their properties"""
-    def __init__(self, serial_reader: SerialReader, model: Model, cfg: Config,
+    def __init__(self, serial_parser: SerialParser, model: Model, cfg: Config,
                  printer: Printer):
         # Sent every time the job id should disappear, appear or update
         self.printer = printer
-        self.serial_reader = serial_reader
-        self.serial_reader.add_handler(OPEN_RESULT_REGEX, self.file_opened)
+        self.serial_parser = serial_parser
+        self.serial_parser.add_handler(OPEN_RESULT_REGEX, self.file_opened)
 
         # Unused
         self.job_id_updated_signal = Signal()  # kwargs: job_id: int

--- a/prusa/link/printer_adapter/informers/state_manager.py
+++ b/prusa/link/printer_adapter/informers/state_manager.py
@@ -11,8 +11,8 @@ from prusa.connect.printer import Printer
 from prusa.connect.printer.const import State, Source
 from ..const import STATE_HISTORY_SIZE, ERROR_REASON_TIMEOUT
 
-from ..input_output.serial.serial_reader import \
-    SerialReader
+from ..input_output.serial.serial_parser import \
+    SerialParser
 from ..interesting_logger import InterestingLogRotator
 from ..model import Model
 from ..structures.mc_singleton import MCSingleton
@@ -96,10 +96,10 @@ class StateManager(metaclass=MCSingleton):
     # pylint: disable=too-many-instance-attributes,
     # pylint: disable=too-many-public-methods
     # pylint: disable=too-many-arguments
-    def __init__(self, serial_reader: SerialReader, model: Model,
+    def __init__(self, serial_parser: SerialParser, model: Model,
                  sdk_printer: Printer, cfg: Config, settings: Settings):
 
-        self.serial_reader: SerialReader = serial_reader
+        self.serial_parser: SerialParser = serial_parser
         self.model: Model = model
         self.sdk_printer: Printer = sdk_printer
         self.cfg = cfg
@@ -179,7 +179,7 @@ class StateManager(metaclass=MCSingleton):
         }
 
         for regex, handler in regex_handlers.items():
-            self.serial_reader.add_handler(regex, handler)
+            self.serial_parser.add_handler(regex, handler)
 
         error_states = get_printer_error_states()
         for state in error_states:

--- a/prusa/link/printer_adapter/informers/telemetry_gatherer.py
+++ b/prusa/link/printer_adapter/informers/telemetry_gatherer.py
@@ -9,7 +9,7 @@ from ..const import PRINTING_STATES, \
     TELEMETRY_INTERVAL, SLOW_TELEMETRY
 from ..input_output.serial.instruction import MandatoryMatchableInstruction
 from ..input_output.serial.serial_queue import SerialQueue
-from ..input_output.serial.serial_reader import SerialReader
+from ..input_output.serial.serial_parser import SerialParser
 from ..input_output.serial.helpers import \
     wait_for_instruction, enqueue_matchable
 from ..model import Model
@@ -29,7 +29,7 @@ class TelemetryGatherer(ThreadedUpdatable):
     thread_name = "telemetry"
     update_interval = TELEMETRY_INTERVAL
 
-    def __init__(self, serial_reader: SerialReader, serial_queue: SerialQueue,
+    def __init__(self, serial_parser: SerialParser, serial_queue: SerialQueue,
                  model: Model):
 
         self.updated_signal = Signal()  # kwargs: telemetry: Telemetry
@@ -49,7 +49,7 @@ class TelemetryGatherer(ThreadedUpdatable):
         #                                               total: int
 
         self.model = model
-        self.serial_reader = serial_reader
+        self.serial_parser = serial_parser
         self.serial_queue = serial_queue
         self.current_telemetry = Telemetry()
 
@@ -78,7 +78,7 @@ class TelemetryGatherer(ThreadedUpdatable):
         }
 
         for regex, handler in regex_handlers.items():
-            self.serial_reader.add_handler(regex, handler)
+            self.serial_parser.add_handler(regex, handler)
 
         super().__init__()
 

--- a/prusa/link/printer_adapter/input_output/lcd_printer.py
+++ b/prusa/link/printer_adapter/input_output/lcd_printer.py
@@ -7,7 +7,7 @@ from ..const import FW_MESSAGE_TIMEOUT, QUIT_INTERVAL
 from ..model import Model
 from .serial.helpers import enqueue_instruction, wait_for_instruction
 from .serial.serial_queue import SerialQueue
-from .serial.serial_reader import SerialReader
+from .serial.serial_parser import SerialParser
 from ..structures.mc_singleton import MCSingleton
 from ..structures.regular_expressions import LCD_UPDATE_REGEX
 from ..updatable import prctl_name, Thread
@@ -19,17 +19,17 @@ class LCDPrinter(metaclass=MCSingleton):
     """Reports Prusa Link status on the printer LCD whenever possible"""
     MESSAGE_DURATION = 5
 
-    def __init__(self, serial_queue: SerialQueue, serial_reader: SerialReader,
+    def __init__(self, serial_queue: SerialQueue, serial_parser: SerialParser,
                  model: Model):
         self.serial_queue = serial_queue
-        self.serial_reader = serial_reader
+        self.serial_parser = serial_parser
         self.model = model
 
         self.last_updated = time()
         # When printing from our queue, the "LCD status updated gets printed
         # lets try to ignore those
         self.ignore = 0
-        self.serial_reader.add_handler(LCD_UPDATE_REGEX, self.lcd_updated)
+        self.serial_parser.add_handler(LCD_UPDATE_REGEX, self.lcd_updated)
 
         self.running = True
         self.display_thread: Thread = Thread(target=self.show_status,

--- a/prusa/link/printer_adapter/input_output/serial/serial_parser.py
+++ b/prusa/link/printer_adapter/input_output/serial/serial_parser.py
@@ -1,5 +1,5 @@
 """
-Contains implementation of the SerialReader and Regex pairing classes
+Contains implementation of the SerialParser and Regex pairing classes
 The latter is used by the former for tracking which regular expressions
 have which handlers
 """
@@ -39,7 +39,7 @@ class RegexPairing:
         return self.__str__()
 
 
-class SerialReader(metaclass=MCSingleton):
+class SerialParser(metaclass=MCSingleton):
     """
     It's job is to try and find an appropriate handler for every line that
     we receive from the printer
@@ -58,7 +58,7 @@ class SerialReader(metaclass=MCSingleton):
         signal_list = []
 
         with self.lock:
-            log.debug("Deciding on handlers for line: %s", line)
+            log.debug("Deciding on handlers for line: %s", repr(line))
             for pairing in self.pattern_list:
                 match = pairing.regexp.match(line)
                 if match:

--- a/prusa/link/printer_adapter/lib/serial.py
+++ b/prusa/link/printer_adapter/lib/serial.py
@@ -1,11 +1,11 @@
 """Own Serail class """
-
 import os
 import termios
 import fcntl
 import struct
 
 from select import poll, POLLIN
+from time import time
 
 TIOCM_DTR_str = struct.pack('I', termios.TIOCM_DTR)
 
@@ -24,8 +24,7 @@ class Serial:
         timeout - read operation timeout
         """
         if baudrate not in Serial.baudrates:
-            # pylint: disable=consider-using-f-string
-            raise SerialException("Baudrate `%s` is not supported" % baudrate)
+            raise SerialException(f"Baudrate `{baudrate}` is not supported")
 
         self.timeout = timeout
 
@@ -67,7 +66,7 @@ class Serial:
         tty[5] = termios.B115200
 
         termios.tcsetattr(self.fd, termios.TCSANOW, tty)
-        # TCSAFLUSH set after everything is donegv
+        # TCSAFLUSH set after everything is done
         termios.tcsetattr(self.fd, termios.TCSAFLUSH, tty)
 
         self.__buffer = b''
@@ -82,33 +81,35 @@ class Serial:
         os.close(self.fd)
         self.fd = None
 
-    def __read(self):
+    def __read(self, timeout):
         """Fill internal buffer by read from file descriptor."""
         try:
-            ready = self.__poll.poll(self.timeout * 1000)
+            ready = self.__poll.poll(timeout * 1000)
             if ready and self.fd:
-                self.__buffer = os.read(self.fd, 1024)
+                read_bytes = os.read(self.fd, 1024)
+                self.__buffer += read_bytes
                 return
-            raise SerialException('No data read from device')
         except (BlockingIOError, InterruptedError) as err:
-            # pylint: disable=consider-using-f-string
-            raise SerialException('read failed: {}'.format(err)) from err
+            self.close()
+            raise SerialException(f"read failed: {err}") from err
 
     def readline(self):
         """Return next line from local buffer or from serial port."""
-        if not self.__buffer:
-            self.__read()
+        times_out_at = time() + self.timeout
+        start_at = 0
 
-        line = b''
-        while True:
-            pos = self.__buffer.find(b'\n')
+        while time() < times_out_at:
+            pos = self.__buffer.find(b'\n', start_at)
             if pos >= 0:
-                line += self.__buffer[:pos + 1]
+                line = self.__buffer[:pos + 1]
                 self.__buffer = self.__buffer[pos + 1:]
                 return line
 
-            line += self.__buffer
-            self.__read()
+            start_at = max(0, len(self.__buffer) - 1)
+
+            self.__read(times_out_at - time())
+
+        return b''
 
     def write(self, data: bytes):
         """Write data to serial port."""

--- a/prusa/link/printer_adapter/reporting_ensurer.py
+++ b/prusa/link/printer_adapter/reporting_ensurer.py
@@ -2,7 +2,7 @@
 from time import time
 
 from .input_output.serial.serial_queue import SerialQueue
-from .input_output.serial.serial_reader import SerialReader
+from .input_output.serial.serial_parser import SerialParser
 from .input_output.serial.helpers import \
         enqueue_instruction, wait_for_instruction
 from .const import REPORTING_TIMEOUT
@@ -19,15 +19,15 @@ class ReportingEnsurer(ThreadedUpdatable):
     thread_name = "temp_ensurer"
     update_interval = 10
 
-    def __init__(self, serial_reader: SerialReader, serial_queue: SerialQueue):
+    def __init__(self, serial_parser: SerialParser, serial_queue: SerialQueue):
         super().__init__()
-        self.serial_reader = serial_reader
+        self.serial_parser = serial_parser
         self.serial_queue = serial_queue
-        self.serial_reader.add_handler(
+        self.serial_parser.add_handler(
             TEMPERATURE_REGEX, lambda sender, match: self.temps_recorded())
-        self.serial_reader.add_handler(
+        self.serial_parser.add_handler(
             POSITION_REGEX, lambda sender, match: self.positions_recorded())
-        self.serial_reader.add_handler(
+        self.serial_parser.add_handler(
             FAN_REGEX, lambda sender, match: self.fans_recorded())
 
         self.last_seen_temps = time()


### PR DESCRIPTION
Improve naming by:
- renaming the serial module to serial_adapter
- renaming the serial_reader to serial_parser