### PR TITLE
Change of name / location of printer in PrusaLink fixed (added quotes…

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -11,6 +11,7 @@
       - shows an idle screen with the IP address after 30min
     * Name and location of printer in ini file is wrapped by quotes, "#" sign encoded in URL
     * Fix negative timeout being possible in serial read
+    * Change of name / location of printer in PrusaLink fixed (added quotes, removed from endpoint json)
 
 0.6.0 (2021-12-17)
     * Added endpoint for control of extruder

--- a/prusa/link/web/settings.py
+++ b/prusa/link/web/settings.py
@@ -19,8 +19,8 @@ INVALID_CHARACTERS = ['\'', '\"']
 
 def set_settings_printer(name, location):
     """Set new values to printer settings"""
-    app.daemon.settings.printer.name = name
-    app.daemon.settings.printer.location = location
+    app.daemon.settings.printer.name = f'"{name}"'
+    app.daemon.settings.printer.location = f'"{location}"'
 
 
 def set_settings_user(new_username, new_digest):
@@ -48,8 +48,8 @@ def api_settings(req):
         **{
             "api-key": service_local.api_key,
             "printer": {
-                "name": printer_settings.name,
-                "location": printer_settings.location,
+                "name": printer_settings.name.replace("\"", ""),
+                "location": printer_settings.location.replace("\"", ""),
                 "farm_mode": printer_settings.farm_mode
             }
         })


### PR DESCRIPTION
…, removed from endpoint json)