### PR TITLE
Make PrusaLink stop faster

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -26,6 +26,7 @@
     * Added '/api/files/<target>/<path:re:.+>/raw' endpoint
     * Fix unicode characters in file names breaking lcd printer
     * Make RESET_PRINTER clear the command queue and have priority that way
+    * Made the app stop itself faster
 
 0.6.0 (2021-12-17)
     * Added endpoint for control of extruder

--- a/prusa/link/printer_adapter/command_queue.py
+++ b/prusa/link/printer_adapter/command_queue.py
@@ -35,7 +35,8 @@ class CommandQueue:
         self.command_queue = Queue()
         self.current_command_adapter = None
         self.runner_thread = Thread(target=self.process_queue,
-                                    name="command_queue")
+                                    name="command_queue",
+                                    daemon=True)
         self.enqueue_lock = RLock()
 
     def start(self):

--- a/prusa/link/printer_adapter/file_printer.py
+++ b/prusa/link/printer_adapter/file_printer.py
@@ -86,12 +86,14 @@ class FilePrinter(metaclass=MCSingleton):
         # self.check_failed_print()
 
     def stop(self):
-        """Stop printing thread."""
+        """Indicate to the printing thread to stop"""
         if self.data.printing:
             self.stop_print()
+
+    def wait_stopped(self):
+        """Wait for the printing thread to stop"""
         if self.thread is not None and self.thread.is_alive():
             self.thread.join()
-            log.warning("File printer thread joined")
 
     @property
     def pp_exists(self):
@@ -110,7 +112,8 @@ class FilePrinter(metaclass=MCSingleton):
             raise RuntimeError("Cannot print two things at once")
 
         self.data.file_path = os_path
-        self.thread = Thread(target=self._print, name="file_print")
+        self.thread = Thread(target=self._print, name="file_print",
+                             daemon=True)
         self.data.printing = True
         self.data.stopped_forcefully = False
         self.print_stats.start_time_segment()

--- a/prusa/link/printer_adapter/informers/filesystem/sd_card.py
+++ b/prusa/link/printer_adapter/informers/filesystem/sd_card.py
@@ -147,7 +147,7 @@ class SDCard(ThreadedUpdatable):
         """
         instruction = enqueue_matchable(self.serial_queue, "D3 Ax0fbb C1",
                                         D3_OUTPUT_REGEX)
-        wait_for_instruction(instruction, lambda: self.running)
+        wait_for_instruction(instruction, should_wait_evt=self.quit_evt)
         match = instruction.match()
         if match:
             self.data.is_flash_air = match.group("data") == "01"
@@ -277,7 +277,7 @@ class SDCard(ThreadedUpdatable):
                                          begin_regex=BEGIN_FILES_REGEX,
                                          capture_regex=LFN_CAPTURE,
                                          end_regex=END_FILES_REGEX)
-        wait_for_instruction(instruction, lambda: self.running)
+        wait_for_instruction(instruction, should_wait_evt=self.quit_evt)
 
         if not instruction.captured:
             return None
@@ -400,7 +400,7 @@ class SDCard(ThreadedUpdatable):
         self.data.expecting_insertion = True
         instruction = enqueue_matchable(self.serial_queue, "M21",
                                         SD_PRESENT_REGEX)
-        wait_for_instruction(instruction, lambda: self.running)
+        wait_for_instruction(instruction, should_wait_evt=self.quit_evt)
         self.data.expecting_insertion = False
 
         if not instruction.is_confirmed():

--- a/prusa/link/printer_adapter/informers/filesystem/storage_controller.py
+++ b/prusa/link/printer_adapter/informers/filesystem/storage_controller.py
@@ -92,3 +92,9 @@ class StorageController:
         self.sd_card.stop()
         self.fs_mounts.stop()
         self.dir_mounts.stop()
+
+    def wait_stopped(self):
+        """SWait for storage submodules to quit"""
+        self.sd_card.wait_stopped()
+        self.fs_mounts.wait_stopped()
+        self.dir_mounts.wait_stopped()

--- a/prusa/link/printer_adapter/informers/ip_updater.py
+++ b/prusa/link/printer_adapter/informers/ip_updater.py
@@ -168,10 +168,13 @@ class IPUpdater(ThreadedUpdatable):
         else:
             instruction = enqueue_instruction(self.serial_queue,
                                               f"M552 P{ip_address}")
-        wait_for_instruction(instruction,
-                             lambda: self.running and time() < timeout_at)
+        wait_for_instruction(
+            instruction,
+            lambda: not self.quit_evt.is_set() and time() < timeout_at)
 
-    def stop(self):
-        """Stops the module"""
+    def proper_stop(self):
+        """
+        Stops the ip updater and resets the IP shown in the support menu
+        """
         self.send_ip_to_printer(None, reset=True)
         super().stop()

--- a/prusa/link/printer_adapter/informers/telemetry_gatherer.py
+++ b/prusa/link/printer_adapter/informers/telemetry_gatherer.py
@@ -101,7 +101,8 @@ class TelemetryGatherer(ThreadedUpdatable):
             if to_execute():
                 instruction = enqueue_matchable(self.serial_queue, gcode,
                                                 regexp)
-                wait_for_instruction(instruction, lambda: self.running)
+                wait_for_instruction(instruction,
+                                     should_wait_evt=self.quit_evt)
                 result_handler(instruction)
 
         self.slow_ticker.update()

--- a/prusa/link/printer_adapter/input_output/serial/helpers.py
+++ b/prusa/link/printer_adapter/input_output/serial/helpers.py
@@ -1,5 +1,6 @@
 """Contains helper functions, for instruction enqueuing"""
 import re
+from threading import Event
 from typing import List, Callable
 
 from ..serial.instruction import \
@@ -11,15 +12,17 @@ from ...const import QUIT_INTERVAL
 
 def wait_for_instruction(instruction,
                          should_wait: Callable[[], bool] = lambda: True,
+                         should_wait_evt: Event = Event(),
                          check_every=QUIT_INTERVAL):
     """
     Wait until the instruction is done, or we shouldn't wait anymore
 
     :param instruction: The instruction to wait for
     :param should_wait: a lambda returning true if we should continue waiting
+    :param should_wait_evt: an event, if set, means this should quit
     :param check_every: how fast to consult the should_wait lambda
     """
-    while should_wait():
+    while should_wait() and not should_wait_evt.is_set():
         if instruction.wait_for_confirmation(timeout=check_every):
             break
 

--- a/prusa/link/printer_adapter/input_output/serial/is_planner_fed.py
+++ b/prusa/link/printer_adapter/input_output/serial/is_planner_fed.py
@@ -208,3 +208,4 @@ class IsPlannerFed:
             with open(self.threshold_path, "w",
                       encoding='utf-8') as threshold_file:
                 threshold_file.write(str(self.get_dynamic_threshold()))
+                os.fsync(threshold_file.fileno())

--- a/prusa/link/printer_adapter/input_output/serial/serial_adapter.py
+++ b/prusa/link/printer_adapter/input_output/serial/serial_adapter.py
@@ -46,7 +46,8 @@ class SerialAdapter(metaclass=MCSingleton):
         self._renew_serial_connection()
 
         self.read_thread = Thread(target=self._read_continually,
-                                  name="serial_read_thread")
+                                  name="serial_read_thread",
+                                  daemon=True)
         self.read_thread.start()
 
     def _reopen(self):
@@ -165,4 +166,7 @@ class SerialAdapter(metaclass=MCSingleton):
         """Stops the component"""
         self.running = False
         self.serial.close()
+
+    def wait_stopped(self):
+        """Waits for the serial to be stopped"""
         self.read_thread.join()

--- a/prusa/link/printer_adapter/lcd_printer.py
+++ b/prusa/link/printer_adapter/lcd_printer.py
@@ -537,12 +537,19 @@ class LCDPrinter(metaclass=MCSingleton):
         """Reset the idle time form to the current time"""
         self.idle_from = time()
 
-    def stop(self):
-        """Stops the module"""
+    def stop(self, fast=False):
+        """
+        Stops the module, if not required to go fast, prints a goodbye message
+        """
         self.running = False
         self.add_event(lambda: None)
+        if not fast:
+            self.wait_stopped()
+            self._print_text_and_wait("PrusaLink stopped")
+
+    def wait_stopped(self):
+        """Waits for LCD Printer to quit"""
         self.display_thread.join()
-        self._print_text_and_wait("PrusaLink stopped")
 
     def add_event(self, handler):
         """Adds a handler to the LCDPrinter event queue"""

--- a/prusa/link/printer_adapter/mk3_polling.py
+++ b/prusa/link/printer_adapter/mk3_polling.py
@@ -122,6 +122,10 @@ class MK3Polling:
         """Stops the item updater"""
         self.item_updater.stop()
 
+    def wait_stopped(self):
+        """Waits for the item updater to stop"""
+        self.item_updater.wait_stopped()
+
     def invalidate_printer_info(self):
         """Invalidates all of printer info related watched values"""
         self.item_updater.invalidate_group(self.printer_info)

--- a/prusa/link/printer_adapter/reporting_ensurer.py
+++ b/prusa/link/printer_adapter/reporting_ensurer.py
@@ -72,12 +72,17 @@ class ReportingEnsurer(ThreadedUpdatable):
         The S argument is the frequency of autoreports
         """
         instruction = enqueue_instruction(self.serial_queue, "M155 S2 C7")
-        wait_for_instruction(instruction, lambda: self.running)
+        wait_for_instruction(instruction, should_wait_evt=self.quit_evt)
         self.temps_recorded()
         self.positions_recorded()
         self.fans_recorded()
 
-    def stop(self):
-        """Tries to turn the autoreporting off before stopping"""
-        enqueue_instruction(self.serial_queue, "M155 S0 C0")
+    def proper_stop(self):
+        """
+        Stops the autoreporting ensurer
+        and tries to turn the auto-reporting off
+        """
+        timeout_at = time() + 5
+        instruction = enqueue_instruction(self.serial_queue, "M155 S0 C0")
+        wait_for_instruction(instruction, lambda: time() < timeout_at)
         super().stop()

--- a/prusa/link/printer_adapter/structures/item_updater.py
+++ b/prusa/link/printer_adapter/structures/item_updater.py
@@ -199,6 +199,9 @@ class ItemUpdater:
         self.running = False
         self.invalidate_queue_event.set()
         self.timeout_queue_event.set()
+
+    def wait_stopped(self):
+        """waits for the value tracker to quit"""
         self.invalidator_thread.join()
         self.timeout_thread.join()
         self.refresher_thread.join()

--- a/prusa/link/sdk_augmentation/printer.py
+++ b/prusa/link/sdk_augmentation/printer.py
@@ -136,6 +136,30 @@ class MyPrinter(SDKPrinter, metaclass=MCSingleton):
         self.loop_thread.join()
         self.download_thread.join()
 
+    def indicate_stop(self):
+        """Passes the stop request to all SDK related threads.
+
+        * command handler
+        * loop
+        * inotify
+        """
+        self.__inotify_running = False
+        self.download_mgr.stop_loop()
+        self.stop_loop()
+        self.queue.put(None)  # Trick the SDK into quitting fast
+        self.command_handler.stop()
+
+    def wait_stopped(self):
+        """Waits for the SDK threads to join
+
+        * command handler
+        * loop
+        * inotify
+        """
+        self.inotify_thread.join()
+        self.loop_thread.join()
+        self.download_thread.join()
+
     def loop(self):
         """SDKPrinter.loop with thread name."""
         prctl_name()


### PR DESCRIPTION
Prepare for the eventual fast SD unmounts on printer powerdown. If that ever happens
This can break stuff, but should only do so for stops during specific operations. Shouldn't impact printing and stuff