### PR TITLE
get just the first line of __doc__ as the packge description

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -118,7 +118,7 @@ class BuildStatic(Command):
 
 setup(name="prusa-link",
       version=__version__,
-      description=description,
+      description=description.split("\n", maxsplit=1)[0],
       author="Tomáš Jozífek",
       author_email="tomas.jozifek@prusa3d.cz",
       maintainer="Tomáš Jozífek",


### PR DESCRIPTION
Having more than one line in package description is apparently not allowed. Including a copyright broke installing :smile: 