### PR TITLE
Make http auth fields stricter

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -62,6 +62,7 @@
      * Added storage space info to api/printer
      * Added function for save file with custom name
      * Fix files not reloading when already selected for printing, but overwritten
+     * Exclude diacritic from username
 
 0.6.0 (2021-12-17)
     * Added endpoint for control of extruder

--- a/prusa/link/printer_adapter/structures/regular_expressions.py
+++ b/prusa/link/printer_adapter/structures/regular_expressions.py
@@ -13,8 +13,8 @@ VALID_SN_REGEX = re.compile(r"^(?P<sn>^CZPX\d{4}X\d{3}X.\d{5})$")
 NOZZLE_REGEX = re.compile(r"^(?P<size>\d\.\d+)$")
 PERCENT_REGEX = re.compile(r"^(?P<percent>\d{0,3})%$")
 
-VALID_USERNAME_REGEX = re.compile(".{3,256}")
-VALID_PASSWORD_REGEX = re.compile(".{8,}")
+VALID_USERNAME_REGEX = re.compile(r"^[!#-9;-~][ -!#-9;-~]{1,254}[!#-9;-~]$")
+VALID_PASSWORD_REGEX = re.compile(r"^[^ ].{6,}[^ ]$")
 
 BEGIN_FILES_REGEX = re.compile(r"^Begin file list$")
 END_FILES_REGEX = re.compile(r"^End file list$")

--- a/prusa/link/web/wizard.py
+++ b/prusa/link/web/wizard.py
@@ -64,7 +64,7 @@ def wizard_auth_post(req):
     form = FieldStorage(req,
                         keep_blank_values=app.keep_blank_values,
                         strict_parsing=app.strict_parsing)
-    app.wizard.username = form.get('username', '').strip()
+    app.wizard.username = form.get('username', '')
     password = form.get('password', '')
     repassword = form.get('repassword', '')
     app.wizard.api_key = form.get('api_key', '').strip()


### PR DESCRIPTION
Protinávrh, nerušit jen diakritiku, ale zrušit všechny potenciálně problematický znaky a dvojtečku z username
Dvojtečka je podle RFC2617 zakázaná https://datatracker.ietf.org/doc/html/rfc2617
Zbytek jsem vyházel kvůli tomuhle stack overflow postu https://stackoverflow.com/questions/702629/utf-8-characters-mangled-in-http-basic-auth-username