### PR TITLE
MESH_BED_DATA

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -76,6 +76,7 @@
      * Added endpoint for unregistering the printer
      * Reset print stats after a print ends
      * Fix print fail from a unchecked print buffer underflow
+     * Report mesh bed leveling data
 
 0.6.0 (2021-12-17)
     * Added endpoint for control of extruder

--- a/prusa/link/printer_adapter/const.py
+++ b/prusa/link/printer_adapter/const.py
@@ -28,6 +28,8 @@ DATA_PATH = path.abspath(path.join(str(files('prusa.link')), 'data'))
 BASE_STATES = {State.READY, State.BUSY}
 PRINTING_STATES = {State.PRINTING, State.PAUSED, State.FINISHED, State.STOPPED}
 
+MK25_PRINTERS = {PrinterType.I3MK25, PrinterType.I3MK25S}
+
 JOB_ONGOING_STATES = {State.PRINTING, State.PAUSED}
 JOB_ENDING_STATES = BASE_STATES.union(
     {State.FINISHED, State.STOPPED, State.ERROR})

--- a/prusa/link/printer_adapter/structures/regular_expressions.py
+++ b/prusa/link/printer_adapter/structures/regular_expressions.py
@@ -112,3 +112,10 @@ FAN_ERROR_REGEX = re.compile(
     r"^(?P<fan_name>Extruder|Print) fan speed is lower than expected$")
 D3_OUTPUT_REGEX = re.compile(
     r"^(?P<address>\w{2,}) {2}(?P<data>([0-9a-fA-F]{2} ?)+)$")
+MBL_REGEX = re.compile(
+    r"^(?P<no_mbl>Mesh bed leveling not active.)|"
+    r"(Num X,Y: (?P<num_x>\d+),(?P<num_y>\d+))|"
+    r"(?P<mbl_row>([ ]*-?\d+\.\d+)+)$"
+)
+MBL_TRIGGER_REGEX = re.compile(r"^(tmc\d+_home_enter\(axes_mask=0x..\))|"
+                               r"(echo:enqueing \"G80\")")


### PR DESCRIPTION
It's here, mesh bed leveling data are being reported

A "small" hack for MK2.5 included - it's polled on every switch to the ready or print state
A "small" bug present, it switches the printer into a USB print mode every time it polls the MBL data, because it sees the "G" in the G81 g-code