### PR TITLE
Fix custom mountpoints - respect config. No web UI respects them

### DIFF
--- a/prusa/link/printer_adapter/filesystem/mounts.py
+++ b/prusa/link/printer_adapter/filesystem/mounts.py
@@ -155,9 +155,8 @@ class FSMounts(Mounts):
     thread_name = "fs_mounts_thread"
     update_interval = 0  # The waiting is done in epoll timeout instead of here
 
-    def __init__(self, model: Model, mountpoints=None):
-        if mountpoints:
-            FSMounts.paths_to_mount = mountpoints
+    def __init__(self, model: Model, cfg: Config):
+        FSMounts.paths_to_mount = list(cfg.printer.mountpoints)
 
         model.fs_mounts = MountsData(blacklisted_paths=[],
                                      blacklisted_names=[],
@@ -222,7 +221,7 @@ class DirMounts(Mounts):
     having the fs_type of "directory".
     """
     def __init__(self, model: Model, cfg: Config):
-        DirMounts.paths_to_mount = cfg.printer.directories
+        DirMounts.paths_to_mount = list(cfg.printer.directories)
 
         model.dir_mounts = MountsData(blacklisted_paths=[],
                                       blacklisted_names=[],

--- a/prusa/link/printer_adapter/filesystem/storage_controller.py
+++ b/prusa/link/printer_adapter/filesystem/storage_controller.py
@@ -46,7 +46,7 @@ class StorageController:
         self.sd_card.sd_mounted_signal.connect(self.sd_mounted)
         self.sd_card.sd_unmounted_signal.connect(self.sd_unmounted)
 
-        self.fs_mounts = FSMounts(self.model)
+        self.fs_mounts = FSMounts(self.model, cfg)
         self.dir_mounts = DirMounts(self.model, cfg)
         self.fs_mounts.mounted_signal.connect(self.dir_mounted)
         self.fs_mounts.unmounted_signal.connect(self.dir_unmounted)


### PR DESCRIPTION
For the odd chance anyone will want to respect them in the future

Our own rest API seems to ignore them - has the PrusaLink gcodes hardcoded
Anyway, this fixes them at least on my side