### PR TITLE
Support YUYV pixel format on V4L2 driver, convert to JPEG

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ git:
  submodules: false
 
 before_install:
- - sudo apt-get update && sudo apt-get install -y libcap-dev
+ - sudo apt-get update && sudo apt-get install -y libcap-dev libturbojpeg
 
 install:
  - pip3 install git+https://github.com/prusa3d/Prusa-Connect-SDK-Printer.git@master#egg=prusa.connect.sdk.printer

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Git and Pip are needed for installation, while pigpio is only needed if the
 RPi GPIO pins are to be used.
 
 ```bash
-sudo apt install git python3-pip pigpio libcap-dev libmagic1
+sudo apt install git python3-pip pigpio libcap-dev libmagic1 libturbojpeg0
 # for the Raspberry Pi camera module support
 # pre-installed on the newer Raspberry Pi OS images post September 2022
 sudo apt install -y python3-picamera2 --no-install-recommends

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,3 +19,4 @@ bidict
 python-magic
 pyudev
 v4l2py
+PyTurboJPEG


### PR DESCRIPTION
New dependency! libturbojpeg0 on Debian and PyTurboJPEG from pip. The conversion to jpeg takes 0.35s on pi zero for a 1280x1024 image. We might want to throttle that for bigger images. It's not the slowes thing in the world tho, that makes me happy.