### PR TITLE
Fix ip_updater when wireless SSID is non-ASCII

### DIFF
--- a/prusa/link/printer_adapter/ip_updater.py
+++ b/prusa/link/printer_adapter/ip_updater.py
@@ -91,7 +91,7 @@ class IPUpdater(ThreadedUpdatable):
                 if card_info is None:
                     continue
             ssid_bytes = card_info["ssid"]
-            ssid = ssid_bytes.decode("ASCII")
+            ssid = ssid_bytes.decode()
 
         self.data.ssid = ssid
         self.data.is_wireless = is_wireless


### PR DESCRIPTION
After 43e4950, it looks like non-ASCII SSIDs cause PrusaLink to crash on startup. SSIDs are not guaranteed to be ASCII (in fact they aren't guaranteed to be text at all afaik), so it's probably best to just decode as UTF-8

My emoji SSID shows up correctly in the PrusaConnect interface and PrusaLink 0.7.0 can start up again with this PR

Thank you all for your work on PrusaLink/PrusaConnect!