### PR TITLE
Add verification of file existance on HEAD request

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,6 +1,7 @@
 # ChangeLog
 
 0.7.1dev0
+    * Fixed HTTP response status on HEAD request for non-existing files
 
 0.7.0 (2023-05-19)
     * Fixed printer sends info about api key change to Connect after change

--- a/prusa/link/web/files.py
+++ b/prusa/link/web/files.py
@@ -81,6 +81,10 @@ def head_file_info(req, storage, path=None):
     # If no path is inserted, return root of the storage
     path = storage_display_path(storage, path)
 
+    file = file_system.get(path)
+    if not file:
+        raise conditions.FileNotFound()
+
     headers = make_cache_headers(last_modified)
     headers.update(make_headers(storage, path))
     return Response(headers=headers)


### PR DESCRIPTION
HEAD request on non-existing file always returns 200, instead of 404.