### PR TITLE
Only return job if currently printing to match Buddy behavior

### DIFF
--- a/prusa/link/web/main.py
+++ b/prusa/link/web/main.py
@@ -575,7 +575,7 @@ def job_info(req):
     path = job.selected_file_path
     file_system = app.daemon.prusa_link.printer.fs
 
-    if path:
+    if path and job.job_state is not JobState.IDLE:
         file = file_system.get(path)
         storage = "sdcard" if job.from_sd else "local"
         os_path = file_system.get_os_path(path)


### PR DESCRIPTION
Adding condition to `/api/v1/job` to return `204 No Content` when not currently printing to match the [behavior of `/api/v1/status`](https://github.com/prusa3d/Prusa-Link/blob/37efe0efe5141bf90755a7de2c964a2c63f5bb2b/prusa/link/web/main.py#L252) and Buddy firmware.