### PR TITLE
Add Prusa-Firmware release page as an alternative to download newsest…

### DIFF
--- a/prusa/link/templates/wizard.html
+++ b/prusa/link/templates/wizard.html
@@ -126,7 +126,7 @@
                     </div>
                 {% elif not conditions.FW %}
                     <div class="col" style="text-align: center;">Firmware is not up-to-date, please update it!<br /><br />
-                        You can download the latest stable firmware at <a href="https://prusa3d.com/drivers" target="_blank">Drivers, Firmware and Manuals</a> download page.<br />
+                        You can download the latest stable firmware from the <a href="https://help.prusa3d.com/downloads" target="_blank">Prusa Downloads</a> page or <a href="https://github.com/prusa3d/Prusa-Firmware/releases/latest" target="_blank">Prusa-Firmware</a> github repository.<br />
                         Follow the instructions in this <a href="https://help.prusa3d.com/en/guide/upgrading-the-firmware-original-prusa-i3_24720" target="_blank">guide</a>.<br /><br />
                         After upgrading, run this wizard again.
                     </div>


### PR DESCRIPTION
… stable firmware

After reading the https://github.com/prusa3d/Prusa-Link/issues/983 I think it would be a good idea to provide a second download page for the latest stable release.
The github release is published earlier than the Download page and some users may have issues

![image](https://github.com/prusa3d/Prusa-Link/assets/25530011/c4eb707c-186c-45ad-885f-434536bbbc6a)
