### PR TITLE
Fix mmu crc

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,8 @@
 # ChangeLog
 
+0.8.2 (2024-12-18)
+    * Fix crc issue
+
 0.8.1 (2024-06-28)
     * Add a v4l2 workaround so broken camera handles are disqualified from scan
 

--- a/prusa/link/__init__.py
+++ b/prusa/link/__init__.py
@@ -5,8 +5,8 @@
 __application__ = "PrusaLink"
 __vendor__ = "Prusa Research"
 
-__version__ = "0.8.1"
-__date__ = "28 Jun 2024"
+__version__ = "0.8.2"
+__date__ = "18 Dec 2024"
 __copyright__ = "(c) 2024 Prusa 3D"
 __author_name__ = "PrusaLink Developers"
 __author_email__ = "link@prusa3d.cz"

--- a/prusa/link/printer_adapter/structures/regular_expressions.py
+++ b/prusa/link/printer_adapter/structures/regular_expressions.py
@@ -156,21 +156,21 @@ TM_CAL_END_REGEX = re.compile(r"^(TM: calibr\. failed!)|"
                               r"(Thermal Model settings:)$")
 
 MMU_MAJOR_REGEX = re.compile(
-    r"^echo:MMU[23]:<R0 A(?P<number>[0-9a-fA-F]+)\*..\.$")
+    r"^echo:MMU[23]:<R0 A(?P<number>[0-9a-fA-F]+)\*[0-9a-f]{1,2}\.$")
 MMU_MINOR_REGEX = re.compile(
-    r"^echo:MMU[23]:<R1 A(?P<number>[0-9a-fA-F]+)\*..\.$")
+    r"^echo:MMU[23]:<R1 A(?P<number>[0-9a-fA-F]+)\*[0-9a-f]{1,2}\.$")
 MMU_REVISION_REGEX = re.compile(
-    r"^echo:MMU[23]:<R2 A(?P<number>[0-9a-fA-F]+)\*..\.$")
+    r"^echo:MMU[23]:<R2 A(?P<number>[0-9a-fA-F]+)\*[0-9a-f]{1,2}\.$")
 MMU_BUILD_REGEX = re.compile(
-    r"^echo:MMU[23]:<R3 A(?P<number>[0-9a-fA-F]+)\*..\.$")
+    r"^echo:MMU[23]:<R3 A(?P<number>[0-9a-fA-F]+)\*[0-9a-f]{1,2}\.$")
 MMU_SLOT_REGEX = re.compile(
     r"^echo:MMU2:MMU2tool=(?P<slot>\d{1,2})$")
 # This can report an error or a command in progress,
 # we don't know before parsing
 MMU_Q0_RESPONSE_REGEX = re.compile(
     r"^echo:MMU[23]:<(?P<command>[A-Z][0-9a-fA-F]+) "
-    r"(?P<progress>[EFP]([0-9a-fA-F]{0,4}))\*..\.$")
-MMU_Q0_REGEX = re.compile(r"^echo:MMU[23]:>Q0\*..\.$")
+    r"(?P<progress>[EFP]([0-9a-fA-F]{0,4}))\*[0-9a-f]{1,2}\.$")
+MMU_Q0_REGEX = re.compile(r"^echo:MMU[23]:>Q0\*[0-9a-f]{1,2}\.$")
 
 MMU_PROGRESS_REGEX = re.compile(
     r"echo:MMU2:(?P<message>"


### PR DESCRIPTION
User reported an issue with Prusa-Firmware 3.14.1 + MMU 3.0.3, PrusaLink 0.8.1 and PrusaConnect see https://github.com/prusa3d/Prusa-Firmware/issues/4818

After troubleshooting I have found that the MMU 3.0.3 crc value is only one char long instead of being two chars. PrusaLink REGEX expected to have exactly two chars for the crc and so failed to get the correct MMU version including the build number. This causes PrusaLink and PrusaConnect to show the printer as "BUSY" and so not usable with PrusaLink and PrusaConnect.

Prusa-Firmware 3.14.0 with MMU 3.0.2 works fine as the MMU crc is two chars.

This fix accepts one AND two char crc which are 0-9 and a-f.

Changing the Prusa-Firmware and MMU3 firmware isn't a real option as this would also cause the need to change the Prusa-Firmware-Buddy and maybe other 3rd party solutions.

Test:
Before PR:
1. Flash FW 3.14.1 and MMU 3.0.3 firmware
2. Enable MMU
3. Restart the printer
4. Start PrusaLink 0.8.1
5. Open PrusaLink and PrusaConnect
  a. Both show `BUSY` state and the printer is "locked"
6. As a workaround you can disable temporary the MMU in the printer menu, but that also doesn't work always. And after a reboot or new startup the issue is back.

After PR:
1. Flash FW 3.14.1 and MMU 3.0.3 firmware
2. Enable MMU
3. Restart the printer
4. Start PrusaLink 0.8.2
5. Open PrusaLink and PrusaConnect
   a. both show `IDLE`

Also the log files of 0.8.1 in combination of FW 3.14.1+MMU3 shows `ERROR: Gather of mmu_version has failed` 