### PR TITLE
Updated TEMPERATURE_REGEX

### DIFF
--- a/prusa/link/printer_adapter/structures/regular_expressions.py
+++ b/prusa/link/printer_adapter/structures/regular_expressions.py
@@ -98,10 +98,15 @@ ATTENTION_REASON_REGEX = re.compile(
     r"(?P<tm_error>TM: error triggered!)")
 
 TEMPERATURE_REGEX = re.compile(
-    r"^T:(?P<ntemp>-?\d+\.\d+) /(?P<set_ntemp>-?\d+\.\d+) "
-    r"B:(?P<btemp>-?\d+\.\d+) /(?P<set_btemp>-?\d+\.\d+) "
-    r"T0:(-?\d+\.\d+) /(-?\d+\.\d+) @:(?P<tpwm>-?\d+) B@:(?P<bpwm>-?\d+) "
-    r"P:(?P<ptemp>-?\d+\.\d+)( A:(?P<atemp>-?\d+\.\d+))?$")
+    r"^T:(?P<ntemp>-?\d+\.\d+) /(?P<set_ntemp>-?\d+\.\d+)\s+"
+    r"B:(?P<btemp>-?\d+\.\d+) /(?P<set_btemp>-?\d+\.\d+)\s+"
+    r"T0:(-?\d+\.\d+) /(-?\d+\.\d+)\s+"
+    r"@:(?P<tpwm>-?\d+)\s+"
+    r"B@:(?P<bpwm>-?\d+)"
+    r"( P:(?P<ptemp>-?\d+\.\d+))?"
+    r"( A:(?P<atemp>-?\d+\.\d+))?"
+    r"$")
+
 POSITION_REGEX = re.compile(
     r"^X:(?P<x>-?\d+\.\d+) Y:(?P<y>-?\d+\.\d+) Z:(?P<z>-?\d+\.\d+) "
     r"E:(?P<e>-?\d+\.\d+) Count X: (?P<count_x>-?\d+\.\d+) "

--- a/prusa/link/printer_adapter/structures/regular_expressions.py
+++ b/prusa/link/printer_adapter/structures/regular_expressions.py
@@ -103,6 +103,7 @@ TEMPERATURE_REGEX = re.compile(
     r"T0:(-?\d+\.\d+) /(-?\d+\.\d+)\s+"
     r"@:(?P<tpwm>-?\d+)\s+"
     r"B@:(?P<bpwm>-?\d+)"
+    # 'ptemp' is optional due to legacy probe configurations where this value may not be reported.
     r"( P:(?P<ptemp>-?\d+\.\d+))?"
     r"( A:(?P<atemp>-?\d+\.\d+))?"
     r"$")


### PR DESCRIPTION
Modified TEMPERATURE_REGEX, to have the pinda temp as an optional field when matching.

In my case in my pins.h file i have disabled PINDA_THERMISTOR, as my probe does not have any thermistor (old pinda). Due to this in PrusaLink webgui and also in PrusaConnect temperature values under telemetry were not visible, as the regex was not matching due to the pinda field was mandatory.

Fixes my issue: https://github.com/prusa3d/Prusa-Link/issues/1024