### PR TITLE
Strip whitespace from API keys on load, save, and auth comparison

### DIFF
--- a/prusa/link/config.py
+++ b/prusa/link/config.py
@@ -11,6 +11,7 @@ from typing import Iterable
 from extendparser.get import Get
 
 from .const import PRINTER_CONF_TYPES
+from .util import sanitize_api_key
 
 CONNECT = 'connect.prusa3d.com'
 
@@ -310,6 +311,8 @@ class Settings(Get):
             self.get_section('service::local',
                              (('enable', int, 1), ('username', str, ''),
                               ('digest', str, ''), ('api_key', str, ''))))
+        self.service_local['api_key'] = sanitize_api_key(
+            self.service_local['api_key'])
 
         Settings.instance = self
 

--- a/prusa/link/util.py
+++ b/prusa/link/util.py
@@ -34,6 +34,13 @@ from .printer_adapter.structures.model_classes import (
 log = logging.getLogger(__name__)
 
 
+def sanitize_api_key(api_key):
+    """Strip leading and trailing whitespace from an API key value."""
+    if not api_key:
+        return ''
+    return api_key.strip()
+
+
 def prctl_name():
     """Set system thread name with python thread name."""
     # pylint: disable=deprecated-method

--- a/prusa/link/web/lib/auth.py
+++ b/prusa/link/web/lib/auth.py
@@ -11,6 +11,7 @@ from ...printer_adapter.structures.regular_expressions import (
     VALID_PASSWORD_REGEX,
     VALID_USERNAME_REGEX,
 )
+from ...util import sanitize_api_key
 from .core import app
 
 log = logging.getLogger(__name__)
@@ -64,8 +65,8 @@ def check_api_digest(func):
             check_digest(req)
             return func(req, *args, **kwargs)
 
-        api_key = req.headers.get('X-Api-Key')
-        if api_key != app.api_key:
+        api_key = sanitize_api_key(req.headers.get('X-Api-Key'))
+        if api_key != sanitize_api_key(app.api_key):
             res = Response(data="Bad X-Api-Key.",
                            status_code=state.HTTP_FORBIDDEN)
             raise HTTPException(res)

--- a/prusa/link/web/settings.py
+++ b/prusa/link/web/settings.py
@@ -6,6 +6,7 @@ from poorwsgi.digest import check_digest
 from poorwsgi.response import JSONResponse
 
 from ..conditions import SN
+from ..util import sanitize_api_key
 from .lib.auth import (
     REALM,
     check_api_digest,
@@ -47,6 +48,7 @@ def save_settings():
 
 def update_apikey(api_key):
     """Set new value to api-key"""
+    api_key = sanitize_api_key(api_key)
     # Update API key in the app
     app.api_key = api_key
 
@@ -172,7 +174,7 @@ def api_settings_set(req):
 def regenerate_api_key(req):
     """Regenerate Api-Key and save it to settings and config file"""
     # pylint: disable=unused-argument
-    api_key = req.json.get('api-key')
+    api_key = sanitize_api_key(req.json.get('api-key'))
     if api_key:
         if len(api_key) < 7:
             message = "Api-Key must be at least 7 characters long"


### PR DESCRIPTION
## Summary

- Add `sanitize_api_key()` to strip leading/trailing whitespace from API key values
- Sanitize incoming `X-Api-Key` headers and stored keys during auth comparison
- Sanitize keys when saving via `update_apikey()` and when setting via `POST /api/settings/apikey`
- Sanitize keys loaded from `prusa_printer_settings.ini` on startup (persisted back to disk)

## Problem

When copying the Prusa-Link API key into PrusaSlicer, trailing newline/control characters can end up in the client’s stored key. PrusaSlicer then sends a malformed `X-Api-Key` header, and uploads fail with a misleading `HTTP 415: Only G-Code for FDM printer can be uploaded` even though the G-code file is valid. Uploading the same file via the Prusa-Link web UI works because it uses digest auth instead of the API key.

Because invalid API keys may already have been saved via POST /api/settings/apikey, we must assume that the any already stored API keys in Prusalink could have invalid newline/control characters, therefore we need to sanitize any keys that are loaded from prusa_printer_settings.ini as well.

## Related
Complements https://github.com/prusa3d/PrusaSlicer/pull/15448 (client-side API key sanitization).

## Test plan

- [ ] Paste an API key with trailing whitespace via `POST /api/settings/apikey` and confirm it is stored without whitespace
- [ ] Send `X-Api-Key` with trailing `\r`/`\n` and confirm upload/auth succeeds when it matches the stored key
- [ ] Confirm an ini file with whitespace in `api_key` is cleaned on service restart
- [ ] Confirm invalid keys still return `403 Bad X-Api-Key`